### PR TITLE
fix: beforetest failing when project contains existing configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ storage.Tables.delete(id: string): Promise<any>;
 
 You need to set some env variables for the tests:
 - `KBC_URL`
-- `KBC_TOKEN`
+- `KBC_TOKEN` - a *master* token
 - `KBC_COMPONENT` - name of some component used for Components Configurations API tests
 Tests can be run using `yarn test`.
 

--- a/test/Configurations.js
+++ b/test/Configurations.js
@@ -11,7 +11,7 @@ describe('Storage.Configurations', () => {
     const configPromises = [];
     _.each(components, (component) => {
       _.each(component.configurations, (configuration) => {
-        configPromises.push(storage.request('delete', `components/${component}/configs/${configuration}`));
+        configPromises.push(storage.request('delete', `components/${component.id}/configs/${configuration.id}`));
       });
     });
     await Promise.all(configPromises);


### PR DESCRIPTION
fix: beforetest failing when project contains existing configurations