### PR TITLE
Fix check of master token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Javascript client for Keboola Storage API
 
-[![Build Status](https://travis-ci.org/keboola/storage-api-js-client.svg?branch=master)](https://travis-ci.org/keboola/storage-api-js-client)
+[![Build Status](https://travis-ci.com/keboola/storage-api-js-client.svg?branch=master)](https://travis-ci.com/keboola/storage-api-js-client)
 [![Maintainability](https://api.codeclimate.com/v1/badges/9f01593c5e780c783618/maintainability)](https://codeclimate.com/github/keboola/storage-api-js-client/maintainability)
 
 Javascript client for Keboola Connection Storage API. This API client provides client methods to get data from KBC and store data in KBC. The endpoints for working with buckets and tables are covered.

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -69,7 +69,7 @@ export default class Storage {
   async verifyTokenAdmin(): Promise<any> {
     const auth = await this.verifyToken();
     if (!_.has(auth, 'admin')) {
-      Promise.reject(createError(403, 'You need a master Storage token'));
+      throw createError(403, 'You need a master Storage token');
     }
     return auth;
   }


### PR DESCRIPTION
Ta rejekce tiše projde. Chybí tam `return`, ale `throw` bude takhle výstižnější.