### PR TITLE
Data preview & libs maintenance

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,6 +15,7 @@
   "rules": {
     "strict": 0,
     "import/no-extraneous-dependencies": 0,
+    "import/no-cycle": 0,
     "max-len": ["error", {
       "code": 120,
       "ignoreComments": true,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "csv-string": "^3.1.2",
     "http-errors": "^1.7.0",
     "lodash": "^4.17.10",
-    "querystring": "^0.2.0",
+    "qs": "^6.7.0",
     "sleep-promise": "^8.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keboola/storage-api-js-client",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Javascript client for Keboola Storage API",
   "repository": "https://github.com/keboola/storage-api-js-client",
   "author": "Jakub Matejka <jakub@keboola.com>",
@@ -13,7 +13,7 @@
     "aws-sdk": "^2.236.1",
     "axios": "^0.18.0",
     "axios-retry": "^3.1.0",
-    "csv-string": "^3.1.2",
+    "csv-parse": "^4.4.1",
     "http-errors": "^1.7.0",
     "lodash": "^4.17.10",
     "qs": "^6.7.0",
@@ -30,13 +30,13 @@
     "babel-loader": "^8.0.4",
     "eslint": "^5.4.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-flowtype": "^2.50.3",
-    "eslint-plugin-flowtype-errors": "^3.6.0",
+    "eslint-plugin-flowtype": "^3.9.0",
+    "eslint-plugin-flowtype-errors": "^4.1.0",
     "eslint-plugin-import": "^2.14.0",
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.98.1",
     "flow-copy-source": "^2.0.2",
-    "mocha": "^5.1.1",
-    "unexpected": "^10.37.7"
+    "mocha": "^6.1.4",
+    "unexpected": "^11.5.1"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --bail --exit --timeout 0 --require @babel/register --require source-map-support test",

--- a/src/Configurations.js
+++ b/src/Configurations.js
@@ -1,6 +1,6 @@
 // @flow
 import _ from 'lodash';
-import QueryString from 'querystring';
+import qs from 'qs';
 import Storage from './Storage';
 
 export default class Configurations {
@@ -61,7 +61,7 @@ export default class Configurations {
     }
     let uri = 'components';
     if (_.size(params)) {
-      uri += `?${QueryString.stringify(params)}`;
+      uri += `?${qs.stringify(params)}`;
     }
 
     return this.storage.request('get', uri);
@@ -74,7 +74,7 @@ export default class Configurations {
     }
     let uri = `components/${component}/configs`;
     if (_.size(params)) {
-      uri += `?${QueryString.stringify(params)}`;
+      uri += `?${qs.stringify(params)}`;
     }
     return this.storage.request('get', uri);
   }

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
 import createError from 'http-errors';
-import QueryString from 'querystring';
+import qs from 'qs';
 
 import Buckets from './Buckets';
 import Configurations from './Configurations';
@@ -44,7 +44,7 @@ export default class Storage {
       method,
       url,
       headers: { 'X-StorageApi-Token': this.token },
-      data: data ? QueryString.stringify(data) : null,
+      data: data ? qs.stringify(data) : null,
     };
     try {
       const res = await axios(params);

--- a/test/Buckets.js
+++ b/test/Buckets.js
@@ -41,26 +41,26 @@ describe('Storage.Buckets', () => {
     const res = await expect(storage.Buckets.list(), 'to be fulfilled');
     expect(res, 'to be an', 'array');
     if (_.size(res) > 0) {
-      expect(res, 'to have items satisfying', (item) => {
+      expect(res, 'to have items satisfying', expect.it((item) => {
         expect(item, 'to have key', 'id');
         expect(item.id, 'not to be', bucketId);
-      });
+      }));
     }
 
     await storage.request('post', 'buckets', { stage: 'in', name: bucketName });
     const res2 = await expect(storage.Buckets.list(), 'to be fulfilled');
-    expect(res2, 'to have an item satisfying', (item) => {
+    expect(res2, 'to have an item satisfying', expect.it((item) => {
       expect(item, 'to have key', 'id');
       expect(item.id, 'to be', bucketId);
       expect(item, 'not to have key', 'metadata');
-    });
+    }));
 
     const res3 = await expect(storage.Buckets.list(['metadata']), 'to be fulfilled');
-    expect(res3, 'to have an item satisfying', (item) => {
+    expect(res3, 'to have an item satisfying', expect.it((item) => {
       expect(item, 'to have key', 'id');
       expect(item.id, 'to be', bucketId);
       expect(item, 'to have key', 'metadata');
-    });
+    }));
 
     await storage.request('delete', `buckets/${bucketId}`);
   });

--- a/test/Configurations.js
+++ b/test/Configurations.js
@@ -75,9 +75,9 @@ describe('Storage.Configurations', () => {
 
     const res = await expect(storage.Configurations.listComponents(), 'to be fulfilled');
     expect(_.size(res), 'to be greater than', 0);
-    expect(res, 'to have an item satisfying', (i) => {
+    expect(res, 'to have an item satisfying', expect.it((i) => {
       expect(i.id, 'to be', component);
-    });
+    }));
 
     const res2 = await expect(storage.Configurations.list(component), 'to be fulfilled');
     expect(res2, 'to have length', 1);

--- a/test/Tables.js
+++ b/test/Tables.js
@@ -103,6 +103,17 @@ describe('Storage.Tables', () => {
     expect(res.rowsCount, 'to be', 5);
   });
 
+  it('preview', async () => {
+    await createTestTable(storage, bucketId, tableName);
+    await expect(storage.request('get', `tables/${tableId}`), 'to be fulfilled');
+    const res = await storage.Tables.preview(tableId);
+    expect(res, 'to be a', 'array');
+    expect(_.keys(res), 'to have length', 5);
+    expect(res[0], 'to have key', 'id');
+    expect(res[0], 'to have key', 'name');
+    expect(res[0], 'to have key', 'price');
+  });
+
   it('export', async () => {
     await createTestTable(storage, bucketId, tableName);
     await expect(storage.request('get', `tables/${tableId}`), 'to be fulfilled');


### PR DESCRIPTION
- upgrade závislostí
- vyměněná `csv-string` za `csv-parse` (updatovanější a používanější)
- vyměněná `querystring` za `qs` (původní má zjevně bug ve zpracování vnořených polí)
- přidaný support data preview