### PR TITLE
Fix publishing to npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 'releases/*'
 
 jobs:
   test:
@@ -28,21 +27,3 @@ jobs:
           KBC_URL: https://connection.keboola.com
           KBC_TOKEN: ${{ secrets.KBC_TOKEN }}
           KBC_COMPONENT: keboola.ex-db-mysql
-
-  publish:
-    if: github.event.ref_type == 'tag'
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Install dependencies
-        run: yarn install && yarn list --installed
-      - name: Publish
-        run: yarn publish --new-version ${GITHUB_REF#"refs/tags/"} --no-git-tag-version
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: "Publish"
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn install && yarn list --installed
+      - name: Publish
+        run: yarn publish --new-version ${GITHUB_REF#"refs/tags/"} --no-git-tag-version
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Tak ještě fix tý publikace do NPM, takhle vůbec neproběhla. ;o) Rozdělil jsem to na dvě workflow. Build lintuje a testuje a spouští se na pull requestech a pushi do masteru. A publish se spustí po vytvoření releasu.  